### PR TITLE
Add support for custom rpc url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = "1.0"
 solana-client-wasm = { git = "https://github.com/clockwork-xyz/solana-playground", rev = "83e485fbb8f8f09a6411d65ffe63823080847cda" }
 solana-extra-wasm = { git = "https://github.com/clockwork-xyz/solana-playground", rev = "83e485fbb8f8f09a6411d65ffe63823080847cda" }
 url = "2.3.1"
+urlencoding = "2.1.2"
 uuid = { version = "1.3.0", features = ["v4"] }
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.29"

--- a/src/components/connect_button.rs
+++ b/src/components/connect_button.rs
@@ -22,10 +22,18 @@ pub fn ConnectButton(cx: Scope) -> Element {
     let show_popover = use_state(cx, || false);
     let show_cluster_dropdown = use_state(cx, || false);
     let custom_rpc_url = use_ref(cx, || {
-        if let Ok(url) = LocalStorage::get::<String>("customUrl") {
-            url
+        if let Some(ref custom_url_query_param) = route.query_param("customUrl") {
+            if let Ok(url) = LocalStorage::get::<String>("customUrl") {
+                if custom_url_query_param.clone().ne(&url) {
+                    custom_url_query_param.to_string()
+                } else {
+                    url
+                }
+            } else {
+                "http://localhost:8899".to_string()
+            }
         } else {
-            "http://localhost:8899".to_string()
+                "http://localhost:8899".to_string()
         }
     });
     let is_custom_rpc_input_focused = use_ref(cx, || false);

--- a/src/components/connect_button.rs
+++ b/src/components/connect_button.rs
@@ -6,6 +6,7 @@ use gloo_storage::{LocalStorage, Storage};
 use solana_client_wasm::{solana_sdk::pubkey::Pubkey, WasmClient};
 use std::{rc::Rc, str::FromStr};
 use url::Url;
+use wasm_bindgen::{JsCast, UnwrapThrowExt};
 
 use super::backpack::backpack;
 use crate::{
@@ -14,18 +15,28 @@ use crate::{
 };
 
 pub fn ConnectButton(cx: Scope) -> Element {
-    let route = use_route(&cx);
-    let router = use_router(&cx);
+    let route = use_route(cx);
+    let router = use_router(cx);
     let user_context = use_shared_state::<User>(cx).unwrap();
     let cluster_context = use_shared_state::<Cluster>(cx).unwrap();
-    let show_popover = use_state(&cx, || false);
-    let show_cluster_dropdown = use_state(&cx, || false);
+    let show_popover = use_state(cx, || false);
+    let show_cluster_dropdown = use_state(cx, || false);
+    let custom_rpc_url = use_ref(cx, || {
+        if let Ok(url) = LocalStorage::get::<String>("customUrl") {
+            url
+        } else {
+            "http://localhost:8899".to_string()
+        }
+    });
+    let is_custom_rpc_input_focused = use_ref(cx, || false);
+    let cluster_query_param = use_state(cx, || {
+        route
+            .query_param("cluster")
+            .unwrap_or(std::borrow::Cow::Borrowed(""))
+            .into_owned()
+    });
 
-    let cluster_query_param = route
-        .query_param("cluster")
-        .unwrap_or(std::borrow::Cow::Borrowed(""))
-        .into_owned();
-    let url = Url::parse(&route.url().to_string()).unwrap();
+    let url = Url::parse(route.url().as_ref()).unwrap();
     let current_route = if url.path() == "/" {
         String::from("/")
     } else {
@@ -36,6 +47,8 @@ pub fn ConnectButton(cx: Scope) -> Element {
     use_effect(cx, (&url,), |_| {
         let user_context = user_context.clone();
         let cluster_context = cluster_context.clone();
+        let cluster_query_param = cluster_query_param.clone();
+        let custom_rpc_url = custom_rpc_url.clone();
         let current_route = current_route.clone();
 
         to_owned![router];
@@ -48,21 +61,22 @@ pub fn ConnectButton(cx: Scope) -> Element {
                 uc_write.pubkey = user.pubkey;
             }
             update_cluster_and_navigate(
-                cluster_query_param,
+                cluster_query_param.to_string(),
                 cluster_context,
                 &router,
                 &current_route,
+                custom_rpc_url.read().clone(),
             );
         }
     });
 
-    // wallet connect flow
+    // wallet connect flow and set popover state
     let handle_click = move |_| {
         cx.spawn({
             let user_context = user_context.clone();
             let cluster_context = cluster_context.clone();
             let show_popover = show_popover.clone();
-            let cluster_context = cluster_context.clone();
+            let cluster_context = cluster_context;
             async move {
                 let user_context_read = user_context.read();
                 let cluster_context = cluster_context.read();
@@ -75,7 +89,6 @@ pub fn ConnectButton(cx: Scope) -> Element {
                         if !backpack.is_connected() {
                             backpack.connect().await;
                         }
-                        log::info!("connected: {:?}", backpack.is_connected());
                         if backpack.is_connected() {
                             let client = WasmClient::new_with_config(cluster_context.to_owned());
                             let pubkey =
@@ -84,9 +97,8 @@ pub fn ConnectButton(cx: Scope) -> Element {
                             match account {
                                 Ok(acc) => {
                                     drop(user_context_read);
-                                    user_context.write().account = Some(acc.clone());
+                                    user_context.write().account = Some(acc);
                                     user_context.write().pubkey = Some(pubkey);
-                                    log::info!("A");
                                     LocalStorage::set(
                                         "user_context",
                                         User {
@@ -111,35 +123,74 @@ pub fn ConnectButton(cx: Scope) -> Element {
         });
     };
 
-    use_future(&cx, (), |_| {
+    // handle cluster change from dropdown and if rpc url input focused
+    use_future(cx, (), |_| {
         let cluster_context = cluster_context.clone();
         let show_cluster_dropdown = show_cluster_dropdown.clone();
+        let custom_rpc_url = custom_rpc_url.clone();
+        let current_route = current_route.clone();
+        let is_custom_rpc_input_focused = is_custom_rpc_input_focused.clone();
         to_owned![router];
 
         async move {
             let document = gloo_utils::document();
-            Some(EventListener::new(&document, "click", move |_| {
+            EventListener::new(&document, "click", move |_| {
                 let document = gloo_utils::document();
                 if let Some(element) = document.active_element() {
                     let element_id = element.id();
                     let e_id = element_id.as_str();
                     match e_id {
-                        "mainnet" | "devnet" => {
+                        "mainnet" | "devnet" | "custom" => {
                             let cluster = Cluster::from_str(e_id).unwrap();
-                            *cluster_context.write() = cluster;
-                            LocalStorage::set("cluster", cluster.to_string().to_lowercase())
-                                .unwrap();
-                            router.navigate_to(
-                                format!("{}?cluster={}", current_route, cluster.to_string())
-                                    .as_str(),
+                            update_cluster_and_navigate(
+                                cluster.to_string(),
+                                cluster_context.clone(),
+                                &router,
+                                &current_route,
+                                custom_rpc_url.read().clone(),
                             );
                             let _ = web_sys::window().unwrap().location().reload();
                             show_cluster_dropdown.set(false);
                         }
+                        "custom_rpc_input" => {
+                            *is_custom_rpc_input_focused.write() = true;
+                        }
                         _ => {}
                     }
                 }
-            }))
+            })
+        }
+    });
+
+    // handle for custom rpc url change and navigate
+    use_future(cx, (), |_| {
+        let is_custom_rpc_input_focused = is_custom_rpc_input_focused.clone();
+        let cluster_context = cluster_context.clone();
+        let custom_rpc_url = custom_rpc_url.clone();
+        let current_route = current_route.clone();
+        let show_cluster_dropdown = show_cluster_dropdown.clone();
+        to_owned![router];
+
+        async move {
+            let document = gloo_utils::document();
+            EventListener::new(&document, "keydown", move |event| {
+                let event = event.dyn_ref::<web_sys::KeyboardEvent>().unwrap_throw();
+                if event.key().as_str() == "Enter"
+                    && *is_custom_rpc_input_focused.read()
+                    && custom_rpc_url.read().ne(&cluster_context.read().url())
+                {
+                    // trigger refresh with new custom url
+                    update_cluster_and_navigate(
+                        "custom".to_string(),
+                        cluster_context.clone(),
+                        &router,
+                        &current_route,
+                        custom_rpc_url.read().clone(),
+                    );
+                    let _ = web_sys::window().unwrap().location().reload();
+                    show_cluster_dropdown.set(false);
+                }
+            })
         }
     });
 
@@ -162,10 +213,6 @@ pub fn ConnectButton(cx: Scope) -> Element {
             }
         })
         .collect();
-    // log::info!(
-    //     "cluster_context.read().cluster: {}",
-    //     cluster_context.read().cluster.to_string()
-    // );
 
     cx.render(rsx! {
         button {
@@ -176,46 +223,88 @@ pub fn ConnectButton(cx: Scope) -> Element {
         if *show_popover.get() {
             rsx! {
                 div {
-                    class: "absolute top-[60px] right-[34px] transform overflow-hidden h-60 flex flex-col rounded-lg bg-slate-800 px-4 pt-5 items-center pb-4 space-y-4 shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6",
+                    class: "bg-slate-800 absolute top-[90px] right-[34px] w-72 flex flex-col items-center shadow-xl sm:rounded-lg transition-all",
                     div {
-                        class: "w-full flex flex-row justify-between",
-                        p {
-                            class: "text-slate-100 font-semibold",
-                            "{connect_text.as_str()}"
+                        class: "px-4 py-5 sm:p-6 space-y-2 w-full",
+                        div {
+                            class: "w-full flex flex-row items-center justify-between space-x-8",
+                            p {
+                                class: "text-slate-100 font-semibold",
+                                "{connect_text.as_str()}"
+                            }
+                            Balance {}
                         }
-                        Balance {}
-                    }
-                    button {
-                        class: "inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
-                        onclick: move |_| { show_cluster_dropdown.set(true) },
-                        "{current_cluster_text}"
-                        svg {
-                            class: "-mr-1 h-5 w-5 text-slate-800", 
-                            view_box: "0 0 20 20",
-                            fill: "currentColor",
-                            path {
-                                fill_rule: "evenodd", 
-                                d: "M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z", 
+                        button {
+                            class: "inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white hover:bg-slate-100 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
+                            onclick: move |_| { show_cluster_dropdown.set(!show_cluster_dropdown) },
+                            "{current_cluster_text}"
+                            svg {
+                                class: "-mr-1 h-5 w-5 text-slate-800", 
+                                view_box: "0 0 20 20",
+                                fill: "currentColor",
+                                path {
+                                    fill_rule: "evenodd", 
+                                    d: "M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z", 
+                                }
                             }
                         }
-                    }
-                    if *show_cluster_dropdown.get() {
-                        rsx! {
-                            div {
-                                id: "div1",
-                                class: "absolute top-[90px] right-[25px] z-0 mt-2 w-[335px] origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none",
-                                div {
-                                    id: "div2",
-                                    class: "py-1",
+                        if *show_cluster_dropdown.get() {
+                            rsx! {
+                                 ul { class:"z-10 mt-2 w-full origin-top-right divide-y divide-gray-200 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none",
                                     button {
-                                        class: "text-slate-800 block px-4 py-2 text-sm",
+                                        class:"text-gray-900 w-full cursor-default select-none p-4 text-sm hover:bg-slate-200",
                                         id: "mainnet",
-                                        "Mainnet"
+                                        div {
+                                            class: "flex flex-col",
+                                            div {
+                                                class: "flex justify-between",
+                                                p {
+                                                    class: "text-normal",
+                                                    "Mainnet"
+                                                }
+                                            }
+                                        }
                                     }
                                     button {
-                                        class: "text-slate-800 block px-4 py-2 text-sm",
+                                        class:"text-gray-900 w-full cursor-default select-none p-4 text-sm hover:bg-slate-200",
                                         id: "devnet",
-                                        "Devnet"
+                                        div {
+                                            class: "flex flex-col",
+                                            div {
+                                                class: "flex justify-between",
+                                                p {
+                                                    class: "text-normal",
+                                                    "Devnet"
+                                                }
+                                            }
+                                        }
+                                    }
+                                    button {
+                                        class:"text-gray-900 w-full cursor-default select-none p-4 text-sm hover:bg-slate-200",
+                                        id: "custom",
+                                        div {
+                                            class: "flex flex-col",
+                                            div {
+                                                class: "flex justify-between",
+                                                p {
+                                                    class: "text-normal",
+                                                    "Custom"
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if cluster_context.read().to_string().eq("custom") {
+                                        rsx! {
+                                            input {
+                                                class: "block w-full rounded-md border-b focus:ring-0 focus:outline-0 px-2 py-2 text-gray-900 shadow-sm sm:text-sm sm:leading-6",
+                                                r#type: "text",
+                                                value: "{custom_rpc_url.read()}",
+                                                id: "custom_rpc_input",
+                                                oninput: move |e| { 
+                                                    custom_rpc_url.set(e.value.clone());
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -249,25 +338,44 @@ fn update_cluster_and_navigate(
     cluster_context: UseSharedState<Cluster>,
     router: &Rc<RouterService>,
     current_route: &str,
+    custom_rpc_url: String,
 ) {
-    let cluster_from_query_param = get_cluster_from_query_param(cluster_query_param);
+    let cluster_from_query_param =
+        get_cluster_from_query_param(cluster_query_param, custom_rpc_url.clone());
     let cached_cluster = get_cached_cluster();
 
     let cluster_to_use = cluster_from_query_param
         .or(cached_cluster
             .as_ref()
-            .map(|s| Cluster::from_str(&s))
+            .map(|s| {
+                if s.eq("custom") {
+                    Ok(Cluster::Custom(custom_rpc_url.clone()))
+                } else {
+                    Cluster::from_str(s)
+                }
+            })
             .transpose()
             .unwrap())
         .unwrap_or_else(|| Cluster::from_str("mainnet").unwrap());
 
-    update_cluster_context_and_cache(cluster_context, cluster_to_use);
-    navigate_to_route_with_cluster(router, current_route, &cluster_to_use.to_string());
+    update_cluster_context_and_cache(
+        cluster_context,
+        cluster_to_use.clone(),
+        custom_rpc_url.clone(),
+    );
+    navigate_to_route_with_cluster(
+        router,
+        current_route,
+        &cluster_to_use.to_string(),
+        custom_rpc_url,
+    );
 }
 
-fn get_cluster_from_query_param(query_param: String) -> Option<Cluster> {
+fn get_cluster_from_query_param(query_param: String, custom_rpc_url: String) -> Option<Cluster> {
     if query_param.eq("devnet") || query_param.eq("mainnet") {
         Cluster::from_str(&query_param).ok()
+    } else if query_param.eq("custom") {
+        Some(Cluster::Custom(custom_rpc_url))
     } else {
         None
     }
@@ -277,16 +385,38 @@ fn get_cached_cluster() -> Option<String> {
     LocalStorage::get::<String>("cluster").ok()
 }
 
-fn update_cluster_context_and_cache(cluster_context: UseSharedState<Cluster>, cluster: Cluster) {
+fn update_cluster_context_and_cache(
+    cluster_context: UseSharedState<Cluster>,
+    cluster: Cluster,
+    custom_rpc_url: String,
+) {
     log::info!("updating cluster cache to: {}", cluster.to_string());
-    *cluster_context.write() = cluster;
-    LocalStorage::set("cluster", &cluster.to_string().to_lowercase()).unwrap();
+    *cluster_context.write() = cluster.clone();
+    LocalStorage::set("cluster", cluster.to_string().to_lowercase()).unwrap();
+    if cluster.to_string() == "custom" {
+        LocalStorage::set("customUrl", custom_rpc_url).unwrap();
+    } else {
+        LocalStorage::set("customUrl", "http://localhost:8899").unwrap();
+    }
 }
 
 fn navigate_to_route_with_cluster(
     router: &Rc<RouterService>,
     current_route: &str,
     cluster_query_param: &str,
+    custom_rpc_url: String,
 ) {
-    router.navigate_to(format!("{}?cluster={}", current_route, cluster_query_param).as_str());
+    if cluster_query_param.eq("custom") {
+        router.navigate_to(
+            format!(
+                "{}?cluster={}&customUrl={}",
+                current_route,
+                cluster_query_param,
+                urlencoding::encode(custom_rpc_url.as_str())
+            )
+            .as_str(),
+        )
+    } else {
+        router.navigate_to(format!("{}?cluster={}", current_route, cluster_query_param).as_str());
+    }
 }

--- a/src/components/connect_button.rs
+++ b/src/components/connect_button.rs
@@ -176,7 +176,6 @@ pub fn ConnectButton(cx: Scope) -> Element {
         let cluster_context = cluster_context.clone();
         let custom_rpc_url = custom_rpc_url.clone();
         let current_route = current_route.clone();
-        let show_cluster_dropdown = show_cluster_dropdown.clone();
         to_owned![router];
 
         async move {
@@ -187,7 +186,6 @@ pub fn ConnectButton(cx: Scope) -> Element {
                     && *is_custom_rpc_input_focused.read()
                     && custom_rpc_url.read().ne(&cluster_context.read().url())
                 {
-                    // trigger refresh with new custom url
                     update_cluster_and_navigate(
                         "custom".to_string(),
                         cluster_context.clone(),
@@ -195,8 +193,8 @@ pub fn ConnectButton(cx: Scope) -> Element {
                         &current_route,
                         custom_rpc_url.read().clone(),
                     );
+                    // trigger refresh with new custom url
                     let _ = web_sys::window().unwrap().location().reload();
-                    show_cluster_dropdown.set(false);
                 }
             })
         }
@@ -304,7 +302,7 @@ pub fn ConnectButton(cx: Scope) -> Element {
                                     if cluster_context.read().to_string().eq("custom") {
                                         rsx! {
                                             input {
-                                                class: "block w-full rounded-md border-b focus:ring-0 focus:outline-0 px-2 py-2 text-gray-900 shadow-sm sm:text-sm sm:leading-6",
+                                                class: "block w-full rounded-md border-b focus:ring-0 focus:outline-0 px-4 py-2 text-gray-900 shadow-sm sm:text-sm sm:leading-6",
                                                 r#type: "text",
                                                 value: "{custom_rpc_url.read()}",
                                                 id: "custom_rpc_input",
@@ -371,6 +369,7 @@ fn update_cluster_and_navigate(
         cluster_to_use.clone(),
         custom_rpc_url.clone(),
     );
+
     navigate_to_route_with_cluster(
         router,
         current_route,

--- a/src/context/cluster.rs
+++ b/src/context/cluster.rs
@@ -2,11 +2,12 @@ use js_sys::WebAssembly::RuntimeError;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Copy, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum Cluster {
     #[default]
     Mainnet,
     Devnet,
+    Custom(String),
 }
 
 impl Cluster {
@@ -19,6 +20,7 @@ impl Cluster {
                 "https://rpc-devnet.helius.xyz/?api-key=8f29b4e9-37a6-4775-88c6-6f971fe180ca"
                     .to_string()
             }
+            Self::Custom(url) => url.to_string(),
         }
     }
 }
@@ -28,6 +30,7 @@ impl ToString for Cluster {
         match self {
             Self::Mainnet => "mainnet".to_string(),
             Self::Devnet => "devnet".to_string(),
+            Self::Custom(_) => "custom".to_string(),
         }
     }
 }
@@ -39,6 +42,7 @@ impl FromStr for Cluster {
         match expression {
             "mainnet" => Ok(Self::Mainnet),
             "devnet" => Ok(Self::Devnet),
+            "custom" => Ok(Self::Custom("http://localhost::8899".to_string())),
             _ => Err(RuntimeError::new("Invalid expression")),
         }
     }

--- a/src/hot_keys.rs
+++ b/src/hot_keys.rs
@@ -2,34 +2,31 @@ use dioxus::prelude::*;
 use dioxus_router::use_router;
 use gloo_events::EventListener;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
-use web_sys::HtmlElement;
 
 use crate::SearchState;
 
 pub fn HotKeys(cx: Scope) -> Element {
-    let router = use_router(&cx);
+    let router = use_router(cx);
     let search_state = use_shared_state::<SearchState>(cx).unwrap();
-    use_future(&cx, (), |_| {
+    use_future(cx, (), |_| {
         let router = router.clone();
         let search_state = search_state.clone();
         async move {
             let document = gloo_utils::document();
             let mut goto_mode = false;
-            let mut list_index: Option<usize> = None;
             Some(EventListener::new(&document, "keydown", move |event| {
                 let document = gloo_utils::document();
                 let event = event.dyn_ref::<web_sys::KeyboardEvent>().unwrap_throw();
                 match event.key().as_str() {
-                    // "Esc" | "Escape" => {
-                    //     log::info!("Escape!");
-                    //     let mut w_search_state = search_state.write();
-                    //     w_search_state.active = false;
-                    //     w_search_state.query = "".to_string();
-                    // }
                     "/" => {
-                        let mut w_search_state = search_state.write();
-                        w_search_state.active = !w_search_state.active;
-                        w_search_state.query = "".to_string();
+                        if let Some(element) = document.active_element() {
+                            // condition to prevent triggering search when user typing '/' in "https://..."
+                            if element.id().as_str().ne("custom_rpc_input") {
+                                let mut w_search_state = search_state.write();
+                                w_search_state.active = !w_search_state.active;
+                                w_search_state.query = "".to_string();
+                            }
+                        }
                     }
                     "Escape" => {
                         let mut w_search_state = search_state.write();


### PR DESCRIPTION
- add new option in connect wallet button for `custom` rpc
- defaults to `http://localhost:8899`
- if endpoint is invalid then it redirects to `http://localhost:8899`
- cleaned up cluster config dropdown modal
- update `hot_keys.rs` so that when user is typing `/` in input field for custom rpc url it doesn't trigger the search bar 